### PR TITLE
fix: use event capture

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,11 +26,11 @@ const onMounted = (el, binding, vnode) => {
     }
   };
 
-  document.addEventListener(clickEventType(), el[UNIQUE_ID], false);
+  document.addEventListener(clickEventType(), el[UNIQUE_ID], true);
 };
 
 const onUnmounted = (el) => {
-  document.removeEventListener(clickEventType(), el[UNIQUE_ID], false);
+  document.removeEventListener(clickEventType(), el[UNIQUE_ID], true);
   delete el[UNIQUE_ID];
 };
 


### PR DESCRIPTION
A click on the document object should be handled using event capture, since it won't fire if events bound to other elements prevent bubbling